### PR TITLE
Added equals & hashcode to PSRegion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -124,6 +125,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -137,6 +139,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/src/main/java/dev/espi/protectionstones/PSRegion.java
+++ b/src/main/java/dev/espi/protectionstones/PSRegion.java
@@ -29,10 +29,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
 import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -736,5 +733,18 @@ public abstract class PSRegion {
      */
     public RegionManager getWGRegionManager() {
         return rgmanager;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PSRegion psRegion = (PSRegion) o;
+        return Objects.equals(getId(), psRegion.getId()) && Objects.equals(getWorld(), psRegion.getWorld());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(), getWorld());
     }
 }


### PR DESCRIPTION
This is to allow use of `Collection#contains` and `HashSet` for `PSRegion`s.

Also defined missing version tags in pom.xml since they were preventing compilation