### PR TITLE
Fix a small discrepancy

### DIFF
--- a/src/main/resources/config.toml
+++ b/src/main/resources/config.toml
@@ -41,7 +41,7 @@ drop_item_when_inventory_full = true
 
 # Whether or not regions placed have to be either next to or overlapping existing regions the player already owns.
 # This can make the world cleaner and have less scattered regions.
-# Set the number of regions of non-adjacent regions with the permission protectionstones.region.adjacent.x (default is 1, -1 to bypass)
+# Set the number of regions of non-adjacent regions with the permission protectionstones.adjacent.x (default is 1, -1 to bypass)
 # Also can bypass with protectionstones.admin
 regions_must_be_adjacent = false
 


### PR DESCRIPTION
On the config.toml says that the users need this permission `protectionstones.region.adjacent.x` in order to be able to place more non-adjacent regions, however, the permission actually is `protectionstones.adjacent.x` as the wiki describes.