### PR TITLE
Added the feature to unclaim regions remotely

### DIFF
--- a/src/main/java/dev/espi/protectionstones/PSL.java
+++ b/src/main/java/dev/espi/protectionstones/PSL.java
@@ -285,6 +285,7 @@ public enum PSL {
     // ps unclaim
     UNCLAIM_HELP("unclaim.help", ChatColor.AQUA + "> " + ChatColor.GRAY + "/ps unclaim"),
     UNCLAIM_HELP_DESC("unclaim.help_desc", "Use this command to pickup a placed protection stone and remove the region."),
+    UNCLAIM_HEADER("unclaim.header",ChatColor.DARK_GRAY + "" + ChatColor.STRIKETHROUGH + "=====" + ChatColor.RESET + " Unclaim (click to unclaim) " + ChatColor.DARK_GRAY + ChatColor.STRIKETHROUGH + "====="),
 
     // ps view
     VIEW_HELP("view.help", ChatColor.AQUA + "> " + ChatColor.GRAY + "/ps view"),

--- a/src/main/java/dev/espi/protectionstones/PSL.java
+++ b/src/main/java/dev/espi/protectionstones/PSL.java
@@ -73,6 +73,7 @@ public enum PSL {
     NO_PERMISSION_TP("no_permission_tp", ChatColor.RED + "You do not have permission to teleport to other players' protection blocks."),
     NO_PERMISSION_HOME("no_permission_home", ChatColor.RED + "You do not have permission to teleport to your protection blocks."),
     NO_PERMISSION_UNCLAIM("no_permission_unclaim", ChatColor.RED + "You do not have permission to use the unclaim command."),
+    NO_PERMISSION_UNCLAIM_REMOTE("no_permission_unclaim_remote", ChatColor.RED + "You do not have permission to use the unclaim remote command."),
     NO_PERMISSION_VIEW("no_permission_view", ChatColor.RED + "You do not have permission to use the view command."),
     NO_PERMISSION_GIVE("no_permission_give", ChatColor.RED + "You do not have permission to use the give command."),
     NO_PERMISSION_GET("no_permission_get", ChatColor.RED + "You do not have permission to use the get command."),

--- a/src/main/java/dev/espi/protectionstones/commands/ArgUnclaim.java
+++ b/src/main/java/dev/espi/protectionstones/commands/ArgUnclaim.java
@@ -66,6 +66,10 @@ public class ArgUnclaim implements PSCommandArg {
         }
         //Check if /ps unclaim list|PsID
         if (args.length >= 2) {
+            if (!p.hasPermission("protectionstones.unclaim.remote")) {
+                PSL.msg(p, PSL.NO_PERMISSION_UNCLAIM_REMOTE.msg());
+                return true;
+            }
             PSPlayer psp = PSPlayer.fromPlayer(p);
             //Get the list of regions that a player owns
             List<PSRegion> regions = psp.getPSRegionsCrossWorld(psp.getPlayer().getWorld(), false);

--- a/src/main/java/dev/espi/protectionstones/commands/ArgUnclaim.java
+++ b/src/main/java/dev/espi/protectionstones/commands/ArgUnclaim.java
@@ -26,7 +26,10 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 
 public class ArgUnclaim implements PSCommandArg {
 
@@ -62,24 +65,24 @@ public class ArgUnclaim implements PSCommandArg {
             return true;
         }
         //Check if /ps unclaim list|PsID
-        if(args.length >= 2 ){
+        if (args.length >= 2) {
             PSPlayer psp = PSPlayer.fromPlayer(p);
             //Get the list of regions that a player owns
             List<PSRegion> regions = psp.getPSRegionsCrossWorld(psp.getPlayer().getWorld(), false);
-            if(args[1].equalsIgnoreCase("list")) {
-                displayPSRegions(s,regions,args.length == 2 ? 0 : tryParseInt(args[2])-1);
-            }else{
-                for(PSRegion ps : regions){
-                    if(ps.getId().equalsIgnoreCase(args[1])){
+            if (args[1].equalsIgnoreCase("list")) {
+                displayPSRegions(s, regions, args.length == 2 ? 0 : tryParseInt(args[2]) - 1);
+            } else {
+                for (PSRegion ps : regions) {
+                    if (ps.getId().equalsIgnoreCase(args[1])) {
                         // cannot break region being rented (prevents splitting merged regions, and breaking as tenant owner)
                         if (ps.getRentStage() == PSRegion.RentStage.RENTING && !p.hasPermission("protectionstones.superowner")) {
                             PSL.msg(p, PSL.RENT_CANNOT_BREAK_WHILE_RENTING.msg());
                             return false;
                         }
-                        return unclaimBlock(ps,p);
+                        return unclaimBlock(ps, p);
                     }
                 }
-                PSL.msg(p,PSL.REGION_DOES_NOT_EXIST.msg());
+                PSL.msg(p, PSL.REGION_DOES_NOT_EXIST.msg());
             }
             return false;
         }
@@ -101,20 +104,23 @@ public class ArgUnclaim implements PSCommandArg {
         }
         return unclaimBlock(r, p);
     }
+
     @Override
     public List<String> tabComplete(CommandSender sender, String alias, String[] args) {
         return null;
     }
-    private int tryParseInt(String arg){
+
+    private int tryParseInt(String arg) {
         int i = 1;
-        try{
+        try {
             i = Integer.parseInt(arg);
-        }catch(NumberFormatException ignore){
+        } catch (NumberFormatException ignore) {
             //ignore
         }
         return i;
     }
-    private void displayPSRegions(CommandSender s,List<PSRegion> regions,int page){
+
+    private void displayPSRegions(CommandSender s, List<PSRegion> regions, int page) {
         List<TextComponent> entries = new ArrayList<>();
         for (PSRegion rs : regions) {
             String msg;
@@ -124,14 +130,14 @@ public class ArgUnclaim implements PSCommandArg {
                 msg = ChatColor.GRAY + "> " + ChatColor.AQUA + rs.getName() + " (" + rs.getId() + ")";
             }
             TextComponent tc = new TextComponent(ChatColor.AQUA + " [-] " + msg);
-            tc.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder("Click to delete "+rs.getId()).create()));
-            tc.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/ps unclaim " + rs.getId()));
+            tc.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder("Click to delete " + rs.getId()).create()));
+            tc.setClickEvent(new ClickEvent(ClickEvent.Action.SUGGEST_COMMAND, "/" + ProtectionStones.getInstance().getConfigOptions().base_command + " unclaim " + rs.getId()));
             entries.add(tc);
         }
-        TextGUI.displayGUI(s,PSL.UNCLAIM_HEADER.msg(), "/" + ProtectionStones.getInstance().getConfigOptions().base_command + " unclaim list %page%",page,17,entries,true);
+        TextGUI.displayGUI(s, PSL.UNCLAIM_HEADER.msg(), "/" + ProtectionStones.getInstance().getConfigOptions().base_command + " unclaim list %page%", page, 17, entries, true);
     }
 
-    private boolean unclaimBlock(PSRegion r,Player p){
+    private boolean unclaimBlock(PSRegion r, Player p) {
         PSProtectBlock cpb = r.getTypeOptions();
         if (cpb != null && !cpb.noDrop) {
             // return protection stone

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,6 +18,9 @@ permissions:
   protectionstones.unclaim:
     description: Allow players to unclaim their region using /ps unclaim.
     default: op
+  protectionstones.unclaim.remote:
+    description: Allow players to unclaim their region remotely using /ps unclaim list|PsID.
+    default: op
   protectionstones.view:
     description: Allows players the use of /ps view in their own regions.
     default: op


### PR DESCRIPTION
This should add #309 
Syntax:  /ps unclaim list|PsID

Use  /ps unclaim list to get a list of every PSRegion that you own in that world. 
You can click in the chat to get the specific unclaim command like /ps unclaim ps300x64y250z

