### PR TITLE
limit region owners and members by new semi generic perm

### DIFF
--- a/src/main/java/dev/espi/protectionstones/PSL.java
+++ b/src/main/java/dev/espi/protectionstones/PSL.java
@@ -90,6 +90,8 @@ public enum PSL {
     REMOVED_FROM_REGION("psregion.removed_from_region", ChatColor.AQUA + "%player%" + ChatColor.GRAY + " has been removed from region."),
     REMOVED_FROM_REGION_SPECIFIC("psregion.removed_from_region_specific", ChatColor.AQUA + "%player%" + ChatColor.GRAY + " has been removed from region %region%."),
     NOT_IN_REGION("psregion.not_in_region", ChatColor.RED + "You are not in a protection stones region!"),
+    MEMBERS_LIMIT("psregion.members_limit_reached", ChatColor.RED + "Members limit reached (%limit%) for region: %region%"),
+    OWNERS_LIMIT("psregion.owners_limit_reached", ChatColor.RED + "Owners limit reached (%limit%) for region: %region%"),
     PLAYER_NOT_FOUND("psregion.player_not_found", ChatColor.RED + "Player not found."),
     NOT_PS_REGION("psregion.not_ps_region", ChatColor.RED + "Not a protection stones region."),
     REGION_DOES_NOT_EXIST("psregion.region_does_not_exist", ChatColor.RED + "Region does not exist."),

--- a/src/main/java/dev/espi/protectionstones/commands/ArgAddRemove.java
+++ b/src/main/java/dev/espi/protectionstones/commands/ArgAddRemove.java
@@ -119,11 +119,32 @@ public class ArgAddRemove implements PSCommandArg {
             // apply operation to regions
             for (PSRegion r : regions) {
 
+                String regionName = r.getName() == null ? r.getId() : r.getName() + " (" + r.getId() + ")";
                 if (operationType.equals("add") || operationType.equals("addowner")) {
+
+                    // check limit members and owners for a region -> atm if more than one owner
+                    // then, if a second owner has perm with more members/owners, he can add them - possible abuse?
+                    int membersLimit = LimitUtil.getPermissionIntVariable(p, "protectionstones.members-limit.", 2, 0);
+                    int ownersLimit = LimitUtil.getPermissionIntVariable(p, "protectionstones.owners-limit.", 2, 1);
+
+                    if (operationType.equals("add") && r.getMembers().size() >= membersLimit) {
+                        PSL.msg(p, PSL.MEMBERS_LIMIT.msg()
+                                .replace("%limit%", String.valueOf(membersLimit))
+                                .replace("%region%", regionName));
+                        continue;
+                    }
+                    if (operationType.equals("addowner") && r.getOwners().size() >= ownersLimit) {
+                        PSL.msg(p, PSL.OWNERS_LIMIT.msg()
+
+                                .replace("%limit%", String.valueOf(ownersLimit))
+                                .replace("%region%", regionName));
+                        continue;
+                    }
+
                     if (flags.containsKey("-a")) {
                         PSL.msg(p, PSL.ADDED_TO_REGION_SPECIFIC.msg()
                                 .replace("%player%", addPlayerName)
-                                .replace("%region%", r.getName() == null ? r.getId() : r.getName() + " (" + r.getId() + ")"));
+                                .replace("%region%", regionName));
                     } else {
                         PSL.msg(p, PSL.ADDED_TO_REGION.msg().replace("%player%", addPlayerName));
                     }
@@ -137,7 +158,7 @@ public class ArgAddRemove implements PSCommandArg {
                     if (flags.containsKey("-a")) {
                         PSL.msg(p, PSL.REMOVED_FROM_REGION_SPECIFIC.msg()
                                 .replace("%player%", addPlayerName)
-                                .replace("%region%", r.getName() == null ? r.getId() : r.getName() + " (" + r.getId() + ")"));
+                                .replace("%region%", regionName));
                     } else {
                         PSL.msg(p, PSL.REMOVED_FROM_REGION.msg().replace("%player%", addPlayerName));
                     }

--- a/src/main/java/dev/espi/protectionstones/utils/LimitUtil.java
+++ b/src/main/java/dev/espi/protectionstones/utils/LimitUtil.java
@@ -19,11 +19,14 @@ import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import dev.espi.protectionstones.*;
+import org.apache.commons.lang.math.NumberUtils;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
+import org.bukkit.permissions.PermissionAttachmentInfo;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 public class LimitUtil {
 
@@ -178,6 +181,38 @@ public class LimitUtil {
             }
         }
         return "";
+    }
+
+    /**
+     * Getting number variable on end of perm
+     * @param player Bukkit player
+     * @param searchingPerm permission without number variable on end like "protectionstones.owners-limit."
+     * @param varPos position of variable in permission
+     * @param defaultValue default return value if perm not exist
+     * @return perm int variable
+     */
+    public static int getPermissionIntVariable(Player player, String searchingPerm, int varPos, int defaultValue) {
+        //admin check
+        if (player.hasPermission("protectionstones.admin") || player.isOp()) {
+            return 9999;
+        }
+        //getting perm to check
+        Optional<PermissionAttachmentInfo> perm = player.getEffectivePermissions().stream()
+                .filter(p -> p.getPermission().startsWith(searchingPerm)).findFirst();
+        if (perm.isEmpty()) {
+            return defaultValue;
+        }
+        //getting var perm
+        String[] split = perm.get().getPermission().split("\\.");
+        if (split.length < varPos + 1) {
+            return defaultValue;
+        }
+        String limitString = split[varPos];
+
+        if (NumberUtils.isNumber(limitString)) {
+            return Integer.parseInt(limitString);
+        }
+        return defaultValue;
     }
 
 }

--- a/src/main/java/dev/espi/protectionstones/utils/LimitUtil.java
+++ b/src/main/java/dev/espi/protectionstones/utils/LimitUtil.java
@@ -184,7 +184,7 @@ public class LimitUtil {
     }
 
     /**
-     * Getting number variable on end of perm
+     * Getting number variable from permission
      * @param player Bukkit player
      * @param searchingPerm permission without number variable on end like "protectionstones.owners-limit."
      * @param varPos position of variable in permission


### PR DESCRIPTION
protectionstones.members-limit.<integer> default 0
protectionstones.owners-limit.<integer> default 1

perm is necessary to add any member/owner
![image](https://github.com/espidev/ProtectionStones/assets/64568689/fd483076-0d52-4eb1-84d7-7a778895773f)
