### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 16
-      uses: actions/setup-java@v4actions/checkout
+      uses: actions/setup-java@v4
       with:
         java-version: '16'
         distribution: 'temurin'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,16 +15,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up JDK 16
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4actions/checkout
       with:
         java-version: '16'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
       run: mvn -B package --file pom.xml
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: Artifacts
         path: target

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up JDK 16
       uses: actions/setup-java@v4
       with:
-        java-version: '16'
+        java-version: '21'
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 16
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
         java-version: '21'


### PR DESCRIPTION
v3 actions were removed: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Also update the JDK to 21 (which is the minimum required)