### PR TITLE
Feature: drop_as_item config option 

### DIFF
--- a/src/main/java/dev/espi/protectionstones/ListenerClass.java
+++ b/src/main/java/dev/espi/protectionstones/ListenerClass.java
@@ -176,14 +176,18 @@ public class ListenerClass implements Listener {
 
         // return protection stone if no drop option is off
         if (blockOptions != null && !blockOptions.noDrop) {
-            if (!p.getInventory().addItem(blockOptions.createItem()).isEmpty()) {
-                // method will return not empty if item couldn't be added
-                if (ProtectionStones.getInstance().getConfigOptions().dropItemWhenInventoryFull) {
-                    PSL.msg(p, PSL.NO_ROOM_DROPPING_ON_FLOOR.msg());
-                    p.getWorld().dropItem(r.getProtectBlock().getLocation(), blockOptions.createItem());
-                } else {
-                    PSL.msg(p, PSL.NO_ROOM_IN_INVENTORY.msg());
-                    return false;
+            if(blockOptions.dropAsItem){
+                p.getWorld().dropItem(r.getProtectBlock().getLocation(), blockOptions.createItem());
+            }else {
+                if (!p.getInventory().addItem(blockOptions.createItem()).isEmpty()) {
+                    // method will return not empty if item couldn't be added
+                    if (ProtectionStones.getInstance().getConfigOptions().dropItemWhenInventoryFull) {
+                        PSL.msg(p, PSL.NO_ROOM_DROPPING_ON_FLOOR.msg());
+                        p.getWorld().dropItem(r.getProtectBlock().getLocation(), blockOptions.createItem());
+                    } else {
+                        PSL.msg(p, PSL.NO_ROOM_IN_INVENTORY.msg());
+                        return false;
+                    }
                 }
             }
         }

--- a/src/main/java/dev/espi/protectionstones/PSProtectBlock.java
+++ b/src/main/java/dev/espi/protectionstones/PSProtectBlock.java
@@ -133,6 +133,8 @@ public class PSProtectBlock {
     public boolean autoMerge;
     @Path("behaviour.no_drop")
     public boolean noDrop;
+    @Path("behaviour.drop_as_item")
+    public boolean dropAsItem;
     @Path("behaviour.prevent_piston_push")
     public boolean preventPistonPush;
     @Path("behaviour.prevent_explode")

--- a/src/main/resources/block1.toml
+++ b/src/main/resources/block1.toml
@@ -216,6 +216,8 @@ placing_bypasses_wg_passthrough = true
 
     # Disable returning the block when removed/unclaimed?
     no_drop = false
+    # Determines whether the block should drop as an item. Default: false. false = instantly added to the inventory.
+    drop_as_item = false
 
     # Prevents piston pushing of the block. Recommended to keep as true.
     prevent_piston_push = true


### PR DESCRIPTION
to control whether ProtectionStone drops as an item or goes directly to inventory when a player breaks it

>Hey everyone.
I'm trying to make it so that when a player breaks their ProtectionStones, instead of sending them directly to their inventory, they drop as a regular item on the ground.
Is there a config option or any way to do this? Any tips would be greatly appreciated.

Feature request in [discord ](https://discord.com/channels/390942438061113344/676271253824339978/1446054024402047047)